### PR TITLE
Customizar el ID de pedido que se manda a la pasarela

### DIFF
--- a/wc_redsys_payment_gateway.php
+++ b/wc_redsys_payment_gateway.php
@@ -357,6 +357,9 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			function get_redsys_args( $order ) {
 				$order_id = $order->id;
 				$unique_order_id = str_pad( $order_id, 8, '0', STR_PAD_LEFT ) . date( 'is' );
+
+				// Customize order code for TPV
+				$unique_order_id = apply_filters("wc_myredsys_merchant_order_encode", $unique_order_id, $order_id);
 		
 				if ( 'yes' == $this->debug ) {
 					$this->log->add( 'redsys', 'Generating payment form for order #' . $order_id . '. Notify URL: ' . $this->notify_url );
@@ -629,11 +632,18 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				        }
 				        
 				        $received_amount	= $data['Ds_Amount'];
-				        $order_id	= substr( $data['Ds_Order'], 0, 8 );
+				        //$order_id	= substr( $data['Ds_Order'], 0, 8 );
 				        $fuc		= $data['Ds_MerchantCode'];
 				        $currency	= $data['Ds_Currency'];
 				        $response	= $data['Ds_Response'];
 				        $auth_code	= $data['Ds_AuthorisationCode'];
+
+				        // Reverse order code customization
+				        $order_id = apply_filters("wc_myredsys_merchant_order_decode", $data['Ds_Order']);
+				        // If not any change made, do default action
+				        if ( $order_id == $data['Ds_Order'] ) {
+				        	$order_id = substr( $data['Ds_Order'], 0, 8 );
+				        }
 				        
 				        // check to see if the response is valid
 				        if ( $received_signature === $calculated_signature

--- a/wc_redsys_payment_gateway.php
+++ b/wc_redsys_payment_gateway.php
@@ -632,18 +632,14 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				        }
 				        
 				        $received_amount	= $data['Ds_Amount'];
-				        //$order_id	= substr( $data['Ds_Order'], 0, 8 );
+				        $order_id	= substr( $data['Ds_Order'], 0, 8 );
 				        $fuc		= $data['Ds_MerchantCode'];
 				        $currency	= $data['Ds_Currency'];
 				        $response	= $data['Ds_Response'];
 				        $auth_code	= $data['Ds_AuthorisationCode'];
 
 				        // Reverse order code customization
-				        $order_id = apply_filters("wc_myredsys_merchant_order_decode", $data['Ds_Order']);
-				        // If not any change made, do default action
-				        if ( $order_id == $data['Ds_Order'] ) {
-				        	$order_id = substr( $data['Ds_Order'], 0, 8 );
-				        }
+				        $order_id = apply_filters("wc_myredsys_merchant_order_decode", $order_id, $data['Ds_Order']);
 				        
 				        // check to see if the response is valid
 				        if ( $received_signature === $calculated_signature


### PR DESCRIPTION
Hola Jesús Ángel,

por petición de algunos clientes necesitamos que en la pasarela aparezcan las IDs que utilizan en su aplicación de facturación (para temas de contabilidad).

Para conseguir esto hemos añadido dos filtros para que se pueda regenerar la ID que se manda a la pasarela:

* _wc_myredsys_merchant_order_encode_: Para generar la Ds_Order que se mandara a la pasarela.
* _wc_myredsys_merchant_order_decode_: Volver a conseguir la ID de la compra a partir del Ds_Order devuelto por la pasarela.

Un ejemplo de implementación seria (extrapolada de una implementación real):

```php
<?php

function uniqueOrderIdEncode( $unique_order_id, $order_id ){
    $order_id = MyCustomClass::createOrder( $order_id ); // Llamada a la aplicación de facturación para conseguir la ID que se guarda en el metadato '_my_order_id'
    if ( $order_id ):
        $my_order_id = get_post_meta( $order_id, "_my_order_id", TRUE );
        $unique_order_id = str_pad( $my_order_id . date( 'is' ), 12, '0', STR_PAD_LEFT );
    endif;

    return $unique_order_id;
}

function uniqueOrderIdDecode( $unique_order_id ){
    global $wpdb;
    
    $my_order_id = substr( $unique_order_id, 1, 7 );
    $results = $wpdb->get_results( "select post_id, meta_key from " . $wpdb->postmeta . " where meta_key = '_my_order_id' and meta_value = '" . $my_order_id . "'");
    if ( ! empty($results) ):
        $result = array_pop($results);
        $unique_order_id = $result->post_id;
    endif;

    return $unique_order_id;
}

// Generar la Ds_Order
add_filter("wc_myredsys_merchant_order_encode", 'uniqueOrderIdEncode', 1, 2);

// Conseguir la ID de compra de la Ds_Order
add_filter("wc_myredsys_merchant_order_decode", 'uniqueOrderIdDecode');
```

Un saludo,

Manex