### PR TITLE
Get user language from WordPress instead of browser.

### DIFF
--- a/wc_redsys_payment_gateway.php
+++ b/wc_redsys_payment_gateway.php
@@ -420,7 +420,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				if( $this->language == 'no' ) {
 					$language = '0';
 				} else {
-					$customer_language = substr( $_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2 );
+					$customer_language = substr( get_bloginfo("language"), 0, 2 );
 					switch ( $customer_language ) {
 						case 'es':
 							$language = '001';


### PR DESCRIPTION
Get the user language from WordPress instead of the client browser (HTTP_ACCEPT_LANGUAGE).

This makes for a better user experience, because there's no language change between the online shop and the payment process (when Redsys supports the shop's current language).

Fixes #18 